### PR TITLE
fix: set encoding for `createReadStream`

### DIFF
--- a/src/csv-parser.js
+++ b/src/csv-parser.js
@@ -4,7 +4,7 @@ const Papa = require('papaparse');
 class CsvParser {
   /**
    * Create a new instance of CsvHelper.
-   * @param defaultConfig The default options
+   * @param {Papa.ParseLocalConfig} defaultConfig The default options
    */
   constructor(defaultConfig = {}) {
     this.defaultConfig = defaultConfig;
@@ -13,11 +13,11 @@ class CsvParser {
   /**
    * Parse CSV file asynchronously.
    *
-   * @param path Path to the CSV file.
-   * @param config The configuration for the parser.
+   * @param {string} path Path to the CSV file.
+   * @param {Papa.ParseLocalConfig} config The configuration for the parser.
    */
   static parse(path, config = {}) {
-    const sourceFile = createReadStream(path);
+    const sourceFile = createReadStream(path, config.encoding ?? 'utf8');
 
     return new Promise((resolve, reject) => {
       Papa.parse(sourceFile, {
@@ -31,8 +31,8 @@ class CsvParser {
   /**
    * Parse CSV file asynchronously.
    *
-   * @param path Path to the CSV file.
-   * @param config The configuration for the parser.
+   * @param {string} path Path to the CSV file.
+   * @param {Papa.ParseLocalConfig} config The configuration for the parser.
    */
   async parse(path, config = {}) {
     return CsvParser.parse(path, {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

> Put "x" to check

- [x] The commit message follows our [Contributing Guidelines](https://github.com/fityannugroho/idn-area-data/blob/main/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (**optional**, for bug fixes or features)
- [ ] Docs have been added / updated (**optional**, for bug fixes or features)

## PR Type

What kind of change does this PR introduce?

> Please check any kind of changes that applies to this PR using "x"

- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Data change
- [ ] *..... (describe the other type)*

## What is the current behavior?

> Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

The CSV parser misread some character (`°` is read as `��`). See the description of commit 66367b1.

## What is the new behavior?

Undefined encoding may cause the read stream to misread the characters. So that, this commit will set the encoding for read stream. If param `config.encoding` is present, the read stream will be used the same encoding. If not, `utf8` will be used as default.

## Other information

None
