### PR TITLE
ci(publish): update to use trusted publishers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,6 +59,4 @@ jobs:
         run: pnpm run build
 
       - name: Publish to npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: pnpm publish --access public --no-git-checks
+        run: npm publish


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
> Put "x" to check
- [x] The commit message follows our [Contributing Guidelines](https://github.com/fityannugroho/idn-area-data/blob/main/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (**optional**, for bug fixes or features)
- [ ] Docs have been added / updated (**optional**, for bug fixes or features)

## PR Type
What kind of change does this PR introduce?
> Please check any kind of changes that applies to this PR using "x"
- [ ] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Data change
- [ ] _..... (describe the other type)_

## What is the current behavior?
> Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

The publish workflow uses `NODE_AUTH_TOKEN` (a static token) and `pnpm publish`. This requires manual token rotation, misses out on automatic provenance attestations via OIDC, and does not align fully with npm's new Trusted Publishers standard.

## What is the new behavior?
The publish workflow relies on OIDC (Trusted Publishers) by removing the static `NODE_AUTH_TOKEN` environment variable. It also uses `npm publish` directly (instead of `pnpm publish`) to guarantee support for generating provenance attestations automatically via GitHub Actions as specified in the recent npm documentation.

## Other information
> For PR that includes `data change`, you MUST put **the official link to the related government regulations,** so we can review and make sure the data change is legally valid.

None