### PR TITLE
ci(publish): upgrade Node.js to 24.x to fix trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ permissions:
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 run-name: Publish ${{ github.event.release.tag_name }}
 
@@ -29,7 +30,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "22.x"
+          node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
 


### PR DESCRIPTION
## What

- Upgrade Node.js from `22.x` to `24.x` in the publish workflow
- Add `workflow_dispatch` trigger to allow manual re-runs

## Why

The publish workflow was failing with `E404` on the `npm publish` step. Root cause: Node.js 22.x bundles npm 10.9.4 which does **not** support NPM trusted publishing (requires npm CLI >= 11.5.1). Node.js 24.x bundles npm 11.x which meets this requirement.

Reference: https://github.com/orgs/community/discussions/173102

> **Note:** `engines.node` in `package.json` is intentionally kept at `>=22.0.0` — this only changes the CI publishing environment, not the minimum supported Node.js version for consumers of this package.

## Related

Fixes the failed workflow run: https://github.com/fityannugroho/idn-area-data/actions/runs/22216807626/job/64262319460